### PR TITLE
feat(): modify helm chart for adding service account

### DIFF
--- a/charts/vault-raft-snapshot-agent/templates/_helpers.tpl
+++ b/charts/vault-raft-snapshot-agent/templates/_helpers.tpl
@@ -29,3 +29,14 @@ Allow the release namespace to be overridden
 {{- default .Release.Namespace (default dict (index .Values "global")).namespace -}}
 {{- end -}}
 
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "helm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "vault-raft-snapshot-agent.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+

--- a/charts/vault-raft-snapshot-agent/templates/deployment.yaml
+++ b/charts/vault-raft-snapshot-agent/templates/deployment.yaml
@@ -36,6 +36,7 @@ spec:
         {{- end }}
     spec:
       restartPolicy: Always
+      serviceAccountName: {{ include "helm.serviceAccountName" . }}
       containers:
         - name: {{ include "vault-raft-snapshot-agent.name" . }}
           {{- with .Values.deployment.image }}
@@ -48,6 +49,13 @@ spec:
           {{- if not (empty .Values.deployment.extraEnvFrom) }}
           envFrom: {{ toYaml .Values.deployment.extraEnvFrom | nindent 12 }}
           {{- end }}
+          resources:
+            limits:
+              cpu: {{ .Values.deployment.resources.limits.cpu }}
+              memory: {{ .Values.deployment.resources.limits.memory }}
+            requests:
+              cpu: {{ .Values.deployment.resources.requests.cpu }}
+              memory: {{ .Values.deployment.resources.requests.memory }}
           volumeMounts:
             - mountPath: /etc/vault.d/
               name: config

--- a/charts/vault-raft-snapshot-agent/templates/serviceaccount.yaml
+++ b/charts/vault-raft-snapshot-agent/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "helm.serviceAccountName" . }}
+  labels:
+    helm.sh/chart: {{ include "vault-raft-snapshot-agent.chart" . }}
+    app.kubernetes.io/name: {{ include "vault-raft-snapshot-agent.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    component: snapshot-agent
+{{- end }}
+
+

--- a/charts/vault-raft-snapshot-agent/values.yaml
+++ b/charts/vault-raft-snapshot-agent/values.yaml
@@ -48,13 +48,13 @@ deployment:
 
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
+  # -- name of the service account to use.
+  # @default -- chart name according to name settings. `.fullNameOverride` and `.nameOverride` are taken into account
+  name:
+  # -- Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: "vault-raft-snapshot-agent"
 
 # -- Defines the contents of the configuration-file for vault-raft-snapshot-agent.
 #    Except for `local_storage` the keys and values are the same as in the agent's

--- a/charts/vault-raft-snapshot-agent/values.yaml
+++ b/charts/vault-raft-snapshot-agent/values.yaml
@@ -46,6 +46,16 @@ deployment:
   #    UI of a Continuous Delivery Tool like Argo-CD
   revisionHistoryLimit:
 
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "vault-raft-snapshot-agent"
+
 # -- Defines the contents of the configuration-file for vault-raft-snapshot-agent.
 #    Except for `local_storage` the keys and values are the same as in the agent's
 #    [configuration file](https://github.com/Argelbargel/vault-raft-snapshot-agent)


### PR DESCRIPTION
Hi @Argelbargel 

This PR contains some changes in Helm chart in order that a custom service account can be created and used, instead of a default one. Also, added resource quotas and limits in deployment template. 

Thanks!
